### PR TITLE
Feat/api articles like

### DIFF
--- a/back-end/src/controller/articles.ts
+++ b/back-end/src/controller/articles.ts
@@ -256,12 +256,52 @@ const deleteArticleController = async (req: Request, res: Response) => {
   }
 };
 
+/**
+ *  @게시글좋아요추가
+ *  @route POST /articles/:articleId/like
+ *  @access private
+ *  @err 1. 필요한 값이 없을 때
+ *
+ */
+const postArticleLikeController = async (req: Request, res: Response) => {
+  try {
+    const resData = await articlesService.postArticleLikeService(
+      req.user.user_id,
+      req.params.articleId
+    );
+
+    if (resData === constant.NULL_VALUE) {
+      return response.basicResponse(
+        res,
+        returnCode.BAD_REQUEST,
+        false,
+        "필요한 값이 존재하지 않습니다."
+      );
+    }
+
+    return response.basicResponse(
+      res,
+      returnCode.OK,
+      true,
+      "좋아하는 게시물에 추가되었습니다."
+    );
+  } catch (err) {
+    return response.basicResponse(
+      res,
+      returnCode.INTERNAL_SERVER_ERROR,
+      false,
+      `서버 오류: ${err.message}`
+    );
+  }
+};
+
 const articlesController = {
   postArticleController,
   getOneArticleController,
   getAllArticlesController,
   patchArticleController,
   deleteArticleController,
+  postArticleLikeController,
 };
 
 export default articlesController;

--- a/back-end/src/controller/articles.ts
+++ b/back-end/src/controller/articles.ts
@@ -258,14 +258,14 @@ const deleteArticleController = async (req: Request, res: Response) => {
 
 /**
  *  @게시글좋아요추가
- *  @route POST /articles/:articleId/like
+ *  @route POST /articles/:articleId/likes
  *  @access private
  *  @err 1. 필요한 값이 없을 때
  *
  */
-const postArticleLikeController = async (req: Request, res: Response) => {
+const postArticleLikesController = async (req: Request, res: Response) => {
   try {
-    const resData = await articlesService.postArticleLikeService(
+    const resData = await articlesService.postArticleLikesService(
       req.user.user_id,
       req.params.articleId
     );
@@ -279,11 +279,12 @@ const postArticleLikeController = async (req: Request, res: Response) => {
       );
     }
 
-    return response.basicResponse(
+    return response.dataResponse(
       res,
       returnCode.OK,
       true,
-      "좋아하는 게시물에 추가되었습니다."
+      "좋아하는 게시물에 추가/삭제 되었습니다.",
+      resData
     );
   } catch (err) {
     return response.basicResponse(
@@ -301,7 +302,7 @@ const articlesController = {
   getAllArticlesController,
   patchArticleController,
   deleteArticleController,
-  postArticleLikeController,
+  postArticleLikesController,
 };
 
 export default articlesController;

--- a/back-end/src/controller/articles.ts
+++ b/back-end/src/controller/articles.ts
@@ -6,7 +6,7 @@ import returnCode from "../lib/returnCode";
 import constant from "../lib/constant";
 /**
  *  @게시글작성 게시글 작성
- *  @route POST articles
+ *  @route POST /articles
  *  @access private
  *  @err 1. 요청 값이 잘못되었을 경우
  *       2. 존재하지 않는 유저일 경우
@@ -113,14 +113,14 @@ const patchArticleController = async (req: Request, res: Response) => {
 
 /**
  *  @게시글리스트조회
- *  @route GET articles
+ *  @route GET /articles?cursor=
  *  @access public
  *  @err 1. 필요한 값이 없을 경우
  */
 const getAllArticlesController = async (req: Request, res: Response) => {
   try {
     const resData = await articlesService.getAllArticlesService(
-      req.params.cursor
+      req.query.cursor ? String(req.query.cursor) : undefined
     );
 
     return response.dataResponse(

--- a/back-end/src/middlewares/authMiddleware.ts
+++ b/back-end/src/middlewares/authMiddleware.ts
@@ -28,6 +28,7 @@ export const isLogin = async (req: Request, res: Response, next) => {
     const token: string = req.headers.authorization;
     const decoded = jwt.verify(token, config.jwtSecret);
 
+    console.log(`decoded: ${decoded}`);
     const user = await User.findOne({
       where: { email: (decoded as IToken).user.email },
     });

--- a/back-end/src/middlewares/authMiddleware.ts
+++ b/back-end/src/middlewares/authMiddleware.ts
@@ -28,7 +28,16 @@ export const isLogin = async (req: Request, res: Response, next) => {
     const token: string = req.headers.authorization;
     const decoded = jwt.verify(token, config.jwtSecret);
 
-    console.log(`decoded: ${decoded}`);
+    /**
+     * TO DO
+     * 현재는 JWT를 이용하는데 결국에는 DB에 접근을 하고 있다.
+     * 그렇다면 session이 아닌 JWT를 사용하는 장점이 없는 것이 아닌가?
+     * DB를 접근하지 않고도 decoded된 정보를 user에 담아주면 되는데,
+     * 이 때 문제점은 jwt를 무력화할 방법이 없다는 것이다.
+     * 따라서 accessToken과 refreshToken을 구별해야 한다.
+     * 현재는 Sliding Sessions 방법을 이용해서 갱신시켜주고 있지만,
+     *
+     */
     const user = await User.findOne({
       where: { email: (decoded as IToken).user.email },
     });

--- a/back-end/src/models/Board.ts
+++ b/back-end/src/models/Board.ts
@@ -14,7 +14,7 @@ import {
 } from "sequelize-typescript";
 import Comment from "./Comment";
 import File from "./File";
-import Like from "./Like";
+import Likes from "./Likes";
 import Tag from "./Tag";
 import User from "./User";
 
@@ -66,6 +66,6 @@ export default class Board extends Model {
   @HasMany(() => Tag)
   tags: Tag[];
 
-  @HasMany(() => Like)
-  likes: Like[];
+  @HasMany(() => Likes)
+  likes: Likes[];
 }

--- a/back-end/src/models/Likes.ts
+++ b/back-end/src/models/Likes.ts
@@ -9,20 +9,20 @@ import {
   ForeignKey,
   BelongsTo,
   AllowNull,
+  Default,
 } from "sequelize-typescript";
 import Board from "./Board";
 import User from "./User";
 
 @Table({
-  modelName: "Like",
-  tableName: "Like",
+  modelName: "Likes",
+  tableName: "Likes",
   underscored: false,
   timestamps: true,
-  paranoid: true,
   charset: "utf8",
   collate: "utf8_general_ci",
 })
-export default class Like extends Model {
+export default class Likes extends Model {
   @PrimaryKey
   @AutoIncrement
   @Unique
@@ -38,6 +38,10 @@ export default class Like extends Model {
   @AllowNull(false)
   @Column
   public user_id!: number;
+
+  @Default(false)
+  @Column
+  public isDeleted!: boolean;
 
   @BelongsTo(() => Board)
   board: Board;

--- a/back-end/src/models/User.ts
+++ b/back-end/src/models/User.ts
@@ -12,7 +12,7 @@ import {
 } from "sequelize-typescript";
 import Board from "./Board";
 import Comment from "./Comment";
-import Like from "./Like";
+import Likes from "./Likes";
 import Tag from "./Tag";
 
 @Table({
@@ -67,6 +67,6 @@ export default class User extends Model {
   @HasMany(() => Tag)
   tags: Tag[];
 
-  @HasMany(() => Like)
-  likes: Like[];
+  @HasMany(() => Likes)
+  likes: Likes[];
 }

--- a/back-end/src/models/index.ts
+++ b/back-end/src/models/index.ts
@@ -5,7 +5,7 @@ import Board from "./Board";
 import Comment from "./Comment";
 import File from "./File";
 import Tag from "./Tag";
-import Like from "./Like";
+import Likes from "./Likes";
 
 dotenv.config();
 
@@ -18,7 +18,7 @@ export const sequelize = new Sequelize({
   dialect: "mysql",
 });
 
-sequelize.addModels([User, Board, Comment, File, Tag, Like]);
+sequelize.addModels([User, Board, Comment, File, Tag, Likes]);
 
-export { User, Board, Comment, File, Tag, Like };
+export { User, Board, Comment, File, Tag, Likes };
 export default sequelize;

--- a/back-end/src/routes/articles.ts
+++ b/back-end/src/routes/articles.ts
@@ -13,5 +13,10 @@ router.delete(
   isLogin,
   articlesController.deleteArticleController
 );
+router.post(
+  "/:articleId/like",
+  isLogin,
+  articlesController.postArticleLikeController
+);
 
 module.exports = router;

--- a/back-end/src/routes/articles.ts
+++ b/back-end/src/routes/articles.ts
@@ -14,9 +14,9 @@ router.delete(
   articlesController.deleteArticleController
 );
 router.post(
-  "/:articleId/like",
+  "/:articleId/likes",
   isLogin,
-  articlesController.postArticleLikeController
+  articlesController.postArticleLikesController
 );
 
 module.exports = router;

--- a/back-end/src/routes/articles.ts
+++ b/back-end/src/routes/articles.ts
@@ -4,8 +4,8 @@ import { isLogin } from "../middlewares/authMiddleware";
 
 const router = express.Router();
 
+router.get("/", articlesController.getAllArticlesController);
 router.post("/", isLogin, articlesController.postArticleController);
-// router.get("/:cursor", articlesController.getAllArticlesController);
 router.get("/:articleId", articlesController.getOneArticleController);
 router.patch("/:articleId", isLogin, articlesController.patchArticleController);
 router.delete(

--- a/back-end/src/services/articles.ts
+++ b/back-end/src/services/articles.ts
@@ -1,5 +1,5 @@
 import constant from "../lib/constant";
-import { Board, Tag, User } from "../models";
+import { Board, Like, Tag, User } from "../models";
 import { Op } from "sequelize";
 
 /**
@@ -222,12 +222,34 @@ const deleteArticleService = async (userId: number, articleId: string) => {
   return constant.SUCCESS;
 };
 
+/**
+ *  @게시글좋아요추가
+ *  @route POST /articles/:articleId/like
+ *  @access private
+ *  @err 1. 필요한 값이 없을 때
+ *
+ */
+const postArticleLikeService = async (userId: number, articleId: string) => {
+  // 1. 필요한 값이 없을 때
+  if (!userId || !articleId) {
+    return constant.NULL_VALUE;
+  }
+
+  await Like.create({
+    board_id: articleId,
+    user_id: userId,
+  });
+
+  return constant.SUCCESS;
+};
+
 const articlesService = {
   postArticleService,
   getOneArticleService,
   getAllArticlesService,
   patchArticleService,
   deleteArticleService,
+  postArticleLikeService,
 };
 
 export default articlesService;

--- a/back-end/src/services/articles.ts
+++ b/back-end/src/services/articles.ts
@@ -4,7 +4,7 @@ import { Op } from "sequelize";
 
 /**
  *  @게시글작성 게시글 작성
- *  @route POST articles
+ *  @route POST /articles
  *  @access private
  *  @err 1. 요청 값이 잘못되었을 경우
  */
@@ -103,7 +103,7 @@ const patchArticleService = async (
 
 /**
  *  @게시글리스트조회
- *  @route GET articles
+ *  @route GET /articles?cursor=
  *  @access public
  *  @err
  */
@@ -118,7 +118,7 @@ const getAllArticlesService = async (cursor: string | undefined) => {
    */
 
   const limit = 5;
-  if (+cursor === -1 || undefined) cursor = await Board.max("board_id");
+  if (cursor === undefined) cursor = await Board.max("board_id");
 
   const articlesToShow = await Board.findAll({
     limit,

--- a/back-end/src/services/articles.ts
+++ b/back-end/src/services/articles.ts
@@ -130,7 +130,7 @@ const getAllArticlesService = async (cursor: string | undefined) => {
       "thumbnailImageUrl",
       [
         Sequelize.literal(
-          `(SELECT COUNT(*) FROM Likes as likes WHERE Board.board_id = likes.board_id)`
+          `(SELECT COUNT(*) FROM Likes as likes WHERE Board.board_id = likes.board_id AND isDeleted = false)`
         ),
         "likeCounts",
       ],


### PR DESCRIPTION
게시글 좋아요 추가/삭제 기능을 구현했습니다.
- [x] Like 테이블의 MariaDB 예약어 이슈로 Likes 로 테이블 변경
- [x] deletedAt 컬럼을 삭제하고 isDeleted 컬럼을 통해 삭제/추가를 하나의 API로 통합하였습니다.
- [x] Sub Query를 통해 게시글 리스트 조회 시 좋아요 수를 같이 response body에 담아줍니다.